### PR TITLE
fixed the link problem from history page to show page

### DIFF
--- a/app/views/visits/my_past_brunches.html.erb
+++ b/app/views/visits/my_past_brunches.html.erb
@@ -1,7 +1,7 @@
 <h1>My past brunch</h1>
 
 <% @visits.each do |visit| %>
-<h3><%= link_to visit.restaurant.name, visit_path(visit) %></h3>
+<h3><%= link_to visit.restaurant.name, restaurant_path(visit.restaurant) %></h3>
 <%= visit.date %>
 <%= visit.restaurant.address %>
 <%= visit.restaurant.wait_time %>


### PR DESCRIPTION
What changed:
-On history page: put the correct link to each restaurant show page

How to test:
GOTO history page clock on one restaurant-->should take you to restaurant show page