### PR TITLE
Removing edit link if not current user

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -18,6 +18,7 @@ class VisitsController < ApplicationController
     @visit.arrived = true
     @visit.update(visit_params)
     @restaurant = @visit.restaurant
+    # @visit.user = current_user
 
     if @visit.update(visit_params)
       redirect_to restaurant_path(@restaurant)

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -19,9 +19,10 @@
   <p><strong>Comment:</strong> <%= visit.feedback %></p>
 
   <p><strong>Date Visited:</strong> <%= visit.date %></p>
-  <%= link_to "Edit feedback", edit_visit_path(visit) %>
+  <% if visit.user == current_user %>
+    <%= link_to "Edit feedback", edit_visit_path(visit) %>
+  <% end %>
 <% end %>
-
 <%# <%= link_to 'See Reviews', _path, class: "btn btn-success" %>
 
 <%= simple_form_for [ @restaurant, @visit ] do |f| %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_05_25_151102) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
What changed:
-On the Edit feedback link-->made sure that only current user can see that link

How to test:
GOTO browser: create 2 different users and create a new visit for one of them-->the edit link should show under the current user visit and not on the other user's page