### PR TITLE
NO button now retriggers alert timer

### DIFF
--- a/app/javascript/controllers/seated_alert_controller.js
+++ b/app/javascript/controllers/seated_alert_controller.js
@@ -2,10 +2,11 @@ import { Controller } from "stimulus"
 // import 'bootstrap/js/dist/modal'
 
 export default class extends Controller {
-  static targets = ["myModal"]
+  static targets = ["myModal", "noButton"]
 
   connect() {
     console.log(this.myModalTarget)
+    console.log(this.noButtonTarget)
     setTimeout(() => {
       this.myModalTarget.click()
     }, 5000)

--- a/app/views/shared/_seated_modal.html.erb
+++ b/app/views/shared/_seated_modal.html.erb
@@ -17,7 +17,8 @@
       </div>
       <div class="modal-footer d-flex justify-content-center">
         <%= link_to "Yes", visit_arrived_path(@visit), class: "btn btn-primary" %>
-        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">No</button>
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"
+                data-seated-alert-target="noButton" data-action="click->seated-alert#connect">No</button>
         <%= link_to "I'm not going", visit_path(@visit), method: :delete %>
       </div>
     </div>


### PR DESCRIPTION
What changed:
- When clicking "No" on "Are you seated?" alert, it re-triggers alert timer so after 5 secs the alert pops up again.

How to test:
GOTO a restaurant, click "take me there", after 5 secs alert pops up -> click "No", alert should pop up after another 5 secs.