### PR TITLE
Fix directions page (for mobile)

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -4,6 +4,7 @@
   border-radius: 5px;
   text-decoration: none;
   padding: 8px 16px;
+  border: none;
 }
 
 .brunch-button:hover {

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -46,7 +46,6 @@
       </div>
     </div>
 
-
     <button class="btn" data-action="click->see-map-or-list-button#show">
         See Map
     </button>

--- a/app/views/shared/_seated_modal.html.erb
+++ b/app/views/shared/_seated_modal.html.erb
@@ -10,7 +10,7 @@
      data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel"
      aria-hidden="true" role="dialog">
   <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content" style="border-radius: 5px; background-color: #FDF8E1;">
+    <div class="modal-content" style="border-radius: 5px; background-color: #FDF8E1; border: 1px solid #FAE588">
       <div class="modal-header" style="border: none">
         <h5 class="modal-title" id="staticBackdropLabel">Are you seated at <%= @visit.restaurant.name %>?</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/app/views/shared/_seated_modal.html.erb
+++ b/app/views/shared/_seated_modal.html.erb
@@ -10,13 +10,13 @@
      data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel"
      aria-hidden="true" role="dialog">
   <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content" style="border-radius: 5px;">
+    <div class="modal-content" style="border-radius: 5px; background-color: #FDF8E1;">
       <div class="modal-header" style="border: none">
         <h5 class="modal-title" id="staticBackdropLabel">Are you seated at <%= @visit.restaurant.name %>?</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-footer d-flex justify-content-center" style="border: none">
-        <%= link_to "Yes", visit_arrived_path(@visit), class: "brunch-button" %>
+        <%= link_to "Yes", visit_arrived_path(@visit), class: "brunch-button", style: "width: 85px; text-align: center" %>
         <button type="button" class="brunch-button" data-bs-dismiss="modal"
                 data-seated-alert-target="noButton" data-action="click->seated-alert#connect">Not yet</button>
       </div>

--- a/app/views/shared/_seated_modal.html.erb
+++ b/app/views/shared/_seated_modal.html.erb
@@ -10,12 +10,12 @@
      data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel"
      aria-hidden="true" role="dialog">
   <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content">
-      <div class="modal-header">
+    <div class="modal-content" style="border-radius: 5px;">
+      <div class="modal-header" style="border: none">
         <h5 class="modal-title" id="staticBackdropLabel">Are you seated at <%= @visit.restaurant.name %>?</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-footer d-flex justify-content-center">
+      <div class="modal-footer d-flex justify-content-center" style="border: none">
         <%= link_to "Yes", visit_arrived_path(@visit), class: "brunch-button" %>
         <button type="button" class="brunch-button" data-bs-dismiss="modal"
                 data-seated-alert-target="noButton" data-action="click->seated-alert#connect">Not yet</button>

--- a/app/views/shared/_seated_modal.html.erb
+++ b/app/views/shared/_seated_modal.html.erb
@@ -9,17 +9,19 @@
 <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static"
      data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel"
      aria-hidden="true" role="dialog">
-  <div class="modal-dialog">
+  <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="staticBackdropLabel">Are you seated at <%= @visit.restaurant.name %>?</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-footer d-flex justify-content-center">
-        <%= link_to "Yes", visit_arrived_path(@visit), class: "btn btn-primary" %>
-        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"
-                data-seated-alert-target="noButton" data-action="click->seated-alert#connect">No</button>
-        <%= link_to "I'm not going", visit_path(@visit), method: :delete %>
+        <%= link_to "Yes", visit_arrived_path(@visit), class: "brunch-button" %>
+        <button type="button" class="brunch-button" data-bs-dismiss="modal"
+                data-seated-alert-target="noButton" data-action="click->seated-alert#connect">Not yet</button>
+      </div>
+      <div class="text-center">
+        <p><%= link_to "I'm not going", visit_path(@visit), method: :delete, class: "brown-link" %></p>
       </div>
     </div>
   </div>

--- a/app/views/visits/show.html.erb
+++ b/app/views/visits/show.html.erb
@@ -7,7 +7,7 @@
 <div class="container text-center">
   <div class="row">
     <div class="col-sm-12">
-      <div style="width: 100%; height: 550px;"
+      <div style="width: 100%; height: 455px;"
       class="mb-3"
       data-controller="mapdirection"
       data-mapdirection-marker-value="<%= @marker.to_json %>"


### PR DESCRIPTION
What changed:

- Fixed directions page's style for mobile
- Styled "are you seated" alert as per Figma

How to test:
GOTO a restaurant, click "take me there", page + alert should look like Figma