### PR TITLE
Feedback page style

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -13,4 +13,11 @@ p {
 
 .egg-container {
   position: relative;
+
+  img {
+    position: absolute;
+    right: -35px;
+    bottom: -430px;
+    width: 300px
+  }
 }

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,3 +1,4 @@
 // Import page-specific CSS files here.
 @import "home";
 @import "show";
+@import "visit_edit";

--- a/app/assets/stylesheets/pages/_visit_edit.scss
+++ b/app/assets/stylesheets/pages/_visit_edit.scss
@@ -7,4 +7,5 @@
   background-color: $sunnyside-up-yellow;
   padding: 20px;
   border-radius: 5px;
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2)
 }

--- a/app/assets/stylesheets/pages/_visit_edit.scss
+++ b/app/assets/stylesheets/pages/_visit_edit.scss
@@ -1,0 +1,10 @@
+.feedback-pg-container {
+  overflow: hidden;
+  height: 80vh;
+}
+
+.feedback-container {
+  background-color: $sunnyside-up-yellow;
+  padding: 20px;
+  border-radius: 5px;
+}

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="egg-container">
-    <%= image_tag "bkgd_egg.png", style: "position: absolute; right: -35px; bottom: -430px; width: 300px" %>
+    <%= image_tag "bkgd_egg.png" %>
   </div>
 
 </div>

--- a/app/views/visits/edit.html.erb
+++ b/app/views/visits/edit.html.erb
@@ -1,4 +1,4 @@
-<p>Visits edit</p>
+<h1>  </h1>
 
 <%= simple_form_for @visit do |f| %>
   <%= f.input :rating, as: :select, collection: 1..5, include_blank: false %>

--- a/app/views/visits/edit.html.erb
+++ b/app/views/visits/edit.html.erb
@@ -5,11 +5,15 @@
     <%# <p>Wait-time Accuracy Rating</p> %>
   </div>
 
-  <div class="feedback-container m-3">
+  <div class="m-3">
     <%= simple_form_for @visit do |f| %>
-      <%= f.input :rating, as: :select, collection: 1..5, include_blank: false, label: "How accurate was the wait-time?" %>
-      <%= f.input :feedback, placeholder: "Anything you'd like to mention?" %>
-      <%= f.submit "Submit", class: "brunch-button" %>
+      <div class="feedback-container">
+        <%= f.input :rating, as: :select, collection: 1..5, include_blank: false, label: "How accurate was the wait-time?" %>
+        <%= f.input :feedback, placeholder: "Anything you'd like to mention?" %>
+      </div>
+      <div class="text-center mt-2">
+        <%= f.submit "Submit", class: "brunch-button" %>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/visits/edit.html.erb
+++ b/app/views/visits/edit.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="egg-container">
-    <%= image_tag "bkgd_egg.png", style: "bottom: -295px" %>
+    <%= image_tag "bkgd_egg.png", style: "bottom: -285px" %>
   </div>
 
 </div>

--- a/app/views/visits/edit.html.erb
+++ b/app/views/visits/edit.html.erb
@@ -1,7 +1,20 @@
-<h1>  </h1>
+<div class="feedback-pg-container">
 
-<%= simple_form_for @visit do |f| %>
-  <%= f.input :rating, as: :select, collection: 1..5, include_blank: false %>
-  <%= f.input :feedback %>
-  <%= f.submit "Submit" %>
-<% end %>
+  <div class="m-3">
+    <h1> <%= @visit.restaurant.name %> </h1>
+    <%# <p>Wait-time Accuracy Rating</p> %>
+  </div>
+
+  <div class="feedback-container m-3">
+    <%= simple_form_for @visit do |f| %>
+      <%= f.input :rating, as: :select, collection: 1..5, include_blank: false, label: "How accurate was the wait-time?" %>
+      <%= f.input :feedback, placeholder: "Anything you'd like to mention?" %>
+      <%= f.submit "Submit", class: "brunch-button" %>
+    <% end %>
+  </div>
+
+  <div class="egg-container">
+    <%= image_tag "bkgd_egg.png", style: "bottom: -295px" %>
+  </div>
+
+</div>


### PR DESCRIPTION
What changed:
- Styled Feedback page ("edit" page of visits) as per Figma

How to test: 
GOTO the "Edit feedback" link on a restaurant, page should look as below
<img width="516" alt="Screen Shot 2022-05-30 at 11 33 02 AM" src="https://user-images.githubusercontent.com/100733281/171024202-292a068f-8da6-42ee-80f3-f7c6a2167476.png">
: