### PR TITLE
Ignored blank ratings in avg accuracy rating calc

### DIFF
--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -8,7 +8,7 @@
     Accuracy Rating: </span>
       <% ratings = [] %>
       <% @visits.each do |visit| %>
-        <% ratings << visit.rating %>
+        <% ratings << visit.rating unless visit.rating.nil? %>
       <% end %>
       <%= (ratings.sum.to_f / ratings.size).round(1) %>
     </p><br>


### PR DESCRIPTION
What changed:
- Ignored empty rating fields for the avg accuracy rating

How to test:
GOTO a resto, create a blank visit, avg rating should not be affected