### PR TITLE
Fixed x button on thank you alert

### DIFF
--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -4,7 +4,7 @@
     <h2><%= notice %></h2>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"
             data-close-alert-target="thankAlert"
-            data-action="click->close-alert#connect">>
+            data-action="click->close-alert#connect">
     </button>
   </div>
 <% end %>


### PR DESCRIPTION
Changes: Fixed "X" close button on thank you alert

How to test: Go to a resto and give a feedback. Thank you alert should look like this:
<img width="337" alt="Screen Shot 2022-06-01 at 9 19 36 AM" src="https://user-images.githubusercontent.com/100733281/171414016-0c4e3934-dfd5-4f17-8b7c-3d85868e5a30.png">

