### PR TITLE
centered alert modals

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,12 +1,11 @@
 .alert {
   position: fixed;
-  z-index: 1000;
-  padding: 60px;
+  z-index: 1;
+  padding: 50px;
   top: 50vh;
-  right: 82px;
+  width: 300px;
   border-radius: 5px;
   background-color: $sunnyside-up-yellow;
   box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
-  // bottom: 16px;
-  // right: 16px;
+  text-align: center;
 }

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,17 +1,21 @@
 <% if notice %>
-  <div class="alert alert-info alert-dismissible alert-centered fade show m-1" role="alert"
-        data-controller="close-alert">
-    <h2><%= notice %></h2>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"
-            data-close-alert-target="thankAlert"
-            data-action="click->close-alert#connect">
-    </button>
+  <div class="d-flex justify-content-center">
+    <div class="alert alert-info alert-dismissible alert-centered fade show m-1" role="alert"
+          data-controller="close-alert">
+      <h2><%= notice %></h2>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"
+              data-close-alert-target="thankAlert"
+              data-action="click->close-alert#connect">
+      </button>
+    </div>
   </div>
 <% end %>
 <% if alert %>
-  <div class="alert alert-warning alert-dismissible fade show m-1" role="alert">
-    <%= alert %>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
-    </button>
+  <div class="d-flex justify-content-center">
+    <div class="alert alert-warning alert-dismissible alert-centered fade show m-1" role="alert">
+      <%= alert %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+      </button>
+    </div>
   </div>
 <% end %>

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -32,7 +32,7 @@ SimpleForm.setup do |config|
   config.include_default_input_wrapper_class = false
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = 'alert alert-danger'
+  config.error_notification_class = ''
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.


### PR DESCRIPTION
What changed:
- Centered modals per Esteban's comments

How to test: 
- Log out, the alert that pops up should be centered + text should be centered
- When logging in, enter an invalid email -> the alert should be centered
