### PR TITLE
Rounded accuracy rating to 1 decimal point

### DIFF
--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -14,6 +14,6 @@ class Restaurant < ApplicationRecord
 
   def update_avg_rating
     ratings = visits.map(&:rating).compact
-    self.avg_rating = ratings.sum.to_f / ratings.size unless ratings.size.zero?
+    self.avg_rating = (ratings.sum.to_f / ratings.size).round(1) unless ratings.size.zero?
   end
 end


### PR DESCRIPTION
What changed:
- Accuracy rating is rounded to 1 decimal point

How to test:
GOTO a resto & leave ratings. accuracy rating should always have 1 decimal point max