### PR TITLE
Made language text on footer smaller

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     © 2022 brunchtime, inc.
   </div>
   <div class= "d-flex align-items-center justify-content-between">
-    <i class="fas fa-globe"></i> <span style="margin-left: 3px;">English (CA)</span>
+    <i class="fas fa-globe"></i> <span style="margin-left: 3px; font-size: 10px">English (CA)</span>
   </div>
 
 </div>


### PR DESCRIPTION
What changed: 
- "English (CA)" text on footer is smaller per Esteban's comment

