### PR TITLE
Ordered reviews by date, descending

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -40,7 +40,7 @@ class RestaurantsController < ApplicationController
   def show
     @restaurant = Restaurant.find(params[:id])
     @visit = Visit.new
-    @visits = @restaurant.visits.where.not(arrived: false).order(created_at: :desc)
+    @visits = @restaurant.visits.where.not(arrived: false).order(date: :desc)
   end
 
   def toggle_favorite


### PR DESCRIPTION
What changed:
- Ordered reviews by their date (descending) on the restaurant show page

How to check:
GOTO a resto, check that reviews are ordered latest to earliest.