### PR TITLE
 put the restaurant name in italic

### DIFF
--- a/app/views/visits/show.html.erb
+++ b/app/views/visits/show.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center mt-3">
-  <h1>On your way to <%= @restaurant.name %>!</h1>
+  <h1>On your way to <span class="fst-italic"><%= @restaurant.name %></span> !</h1>
   <p><%= @restaurant.address %></p>
 </div>
 


### PR DESCRIPTION
What has changed:
After clicking take me there , the restaurant's name in the title of the direction page should be in italic. ( To break a bit the style of the sentence ) 