### PR TITLE
Made logo, motto, & button move left when on desktop

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -28,3 +28,18 @@ p {
     background-position-x: 102%;
   }
 }
+
+
+.logo-title-container {
+  display: flex;
+  justify-content: center;
+}
+
+@media (min-width: 750px) {
+  .logo-title-container {
+      display: flex;
+      justify-content: start;
+      padding-left: 50px;
+      padding-top: 50px;
+    }
+}

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,13 +1,18 @@
 <div class="home-body">
 
-  <div class="container">
-    <div class="d-flex justify-content-center">
-      <%= image_tag "Brunchtimelogo.png", class: "logo py-5" %>
-    </div>
-    <div class="">
-      <p class="mb-2" style="font-size: 19px"><strong>Queue no more! </strong></p>
-      <p class="pb-4" style="font-size: 18px">Find the right brunch at the right time. </p>
-      <%= link_to 'Find a spot', restaurants_path, class: "brunch-button" %>
+  <div class="logo-title-container">
+    <div class="d-flex flex-column align-items-start"
+        style="margin-top: 30px;
+              padding-left: 40px;
+              padding-right: 40px;">
+      <div class="d-flex justify-content-center">
+        <%= image_tag "Brunchtimelogo.png", class: "logo py-5" %>
+      </div>
+      <div class="home-title">
+        <p class="mb-2" style="font-size: 19px"><strong>Queue no more! </strong></p>
+        <p class="pb-4" style="font-size: 18px">Find the right brunch at the right time. </p>
+        <%= link_to 'Find a spot', restaurants_path, class: "brunch-button" %>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
What changed:
- Made homepage more responsive (log/motto/button display change on mobile vs desktop)

How to test:
GOTO home, when on mobile logo/motto/button should stay centered, & when on desktop they should go left 
