### PR TITLE
Index map desktop fix

### DIFF
--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -4,6 +4,9 @@
 @import "favorites";
 @import "visit_edit";
 
+
+$index-map-height: calc(100vh - 144px);
+
 .background {
   background-color: $runny-egg-yellow;
 }
@@ -16,3 +19,9 @@ h2 {
   color: $hash-brown
 }
 
+
+@media (min-width: 100px) {
+  .map-height-resp {
+    height: $index-map-height !important;
+  }
+}

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -2,7 +2,7 @@
   <div class="d-flex flex-column justify-content-center" data-controller="refresh-list">
     <div data-see-map-or-list-button-target="list" style='z-index: 200;
     overflow-y: scroll;
-    height: 86vh;
+    height: 87vh;
     top: 72px;
     background: rgb(253, 248, 225);
     width: 100vw;
@@ -46,10 +46,10 @@
 
     <div id="map" style="width: 92vw;
     z-index: 100;
-    top: 56px;
-    left: 16px;" class ="mx-auto my-3 position-fixed" data-see-map-or-list-button-target="map">
+    top: 56px;" class="mx-auto d-flex justify-content-center map-height-resp" data-see-map-or-list-button-target="map">
 
       <div style="width: 100%; height: 600px;"
+        class="map-height-resp"
         data-controller="mapbox"
         data-mapbox-markers-value="<%= @markers.to_json %>"
         data-mapbox-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -61,11 +61,13 @@
         <%= render 'list.html', restaurants: @restaurants %>
       </div>
   </div>
-    <button class="brunch-button map-and-list-button mt-1 mb-3 mx-auto" style="width: 92vw;
-    z-index: 400;
-    bottom: 64px;
-    left: 150px;
-    position: fixed;"
+  <div class="d-flex justify-content-center">
+    <button class="brunch-button map-and-list-button mt-1 mb-3 mx-auto"
+            style="width: 92vw;
+                  z-index: 400;
+                  bottom: 64px;
+                  position: fixed;"
             data-action="click->see-map-or-list-button#show">See Map <i class="far fa-map"></i></button>
+  </div>
 
 </div>


### PR DESCRIPTION
What changed:
- "See List" button + map on index page centered on desktop.
- Map covers entire restaurant list on desktop.

How to check:
GOTO /restaurants. Switch from mobile to desktop -> "See List" button & the map should be centered on both mobile + desktop, the map should also completely cover the restaurant list. Check if map works as expected too. 